### PR TITLE
Upgrade mutant dependency

### DIFF
--- a/ruby_event_store.gemspec
+++ b/ruby_event_store.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'mutant', '~> 0.7.8'
-  spec.add_development_dependency 'mutant-rspec', '~> 0.7.8'
+  spec.add_development_dependency 'mutant-rspec', '~> 0.7.9'
 end


### PR DESCRIPTION
* Remove redundant `mutant` dependency. `mutant-rspec` pulls it already
* Updates to freshly released 0.7.9