### PR TITLE
Return the event that the repository returns when appending to stream

### DIFF
--- a/lib/ruby_event_store/actions/append_event_to_stream.rb
+++ b/lib/ruby_event_store/actions/append_event_to_stream.rb
@@ -9,7 +9,6 @@ module RubyEventStore
       def call(stream_name, event, expected_version)
         raise WrongExpectedEventVersion if version_incorrect?(stream_name, expected_version)
         save_event(event, stream_name)
-        event
       end
 
       private

--- a/spec/in_memory/in_memory_repository.rb
+++ b/spec/in_memory/in_memory_repository.rb
@@ -14,7 +14,9 @@ module RubyEventStore
 
     def create(model)
       model.merge!({id: db.length})
-      db.push(OpenStruct.new(model))
+      event = OpenStruct.new(model)
+      db.push(event)
+      event
     end
 
     def delete(condition)


### PR DESCRIPTION
This is potentially a breaking change, as this changes the type/class of what is notified to subscribers in the `broker`.

My rationale for changing this, is that what is now notified to subscribers, is exactly the same as you get when reading events via the facade.