### PR TITLE
Use class names to subscribe events

### DIFF
--- a/lib/ruby_event_store/event.rb
+++ b/lib/ruby_event_store/event.rb
@@ -8,17 +8,20 @@ module RubyEventStore
         singleton_class.__send__(:define_method, key) { value }
       end
 
-      @event_type = args[:event_type] || event_name
       @event_id   = (args[:event_id]  || generate_id).to_s
       @metadata   = args[:metadata]   || {}
       @data       = attributes(args)
       @metadata[:timestamp] ||= Time.now.utc
     end
-    attr_reader :event_type, :event_id, :metadata, :data
+    attr_reader :event_id, :metadata, :data
+
+    def event_type
+      self.class
+    end
 
     def to_h
       {
-          event_type: event_type,
+          event_type: event_type.name,
           event_id:   event_id,
           metadata:   metadata,
           data:       data
@@ -29,18 +32,20 @@ module RubyEventStore
       metadata[:timestamp]
     end
 
+    def ==(other_event)
+      other_event.instance_of?(self.class) && other_event.to_h.eql?(to_h)
+    end
+
+    alias_method :eql?, :==
+
     private
 
     def attributes(args)
-      args.reject { |k| [:event_type, :event_id, :metadata].include? k }
+      args.reject { |k| [:event_id, :metadata].include? k }
     end
 
     def generate_id
       SecureRandom.uuid
-    end
-
-    def event_name
-      self.class.name
     end
   end
 end

--- a/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -12,8 +12,8 @@ RSpec.shared_examples :event_repository do |repository_class|
   end
 
   it 'created event is stored in given stream' do
-    expected_event = {event_type: 'TestDomainEvent', data: {}}
-    created = repository.create(TestDomainEvent.new, 'stream')
+    expected_event = TestDomainEvent.new(data: {})
+    created = repository.create(expected_event, 'stream')
     expect_to_be_like_event(created, expected_event)
     expect_to_be_like_event(repository.read_all_streams_forward(:head, 1).first, expected_event)
     expect_to_be_like_event(repository.read_stream_events_forward('stream').first, expected_event)
@@ -98,8 +98,8 @@ RSpec.shared_examples :event_repository do |repository_class|
   private
 
   def expect_to_be_like_event(actual, expected)
-    expect(actual.event_type).to eq expected[:event_type]
-    expect(actual.data).to eq expected[:data]
-    if expected.key? :event_id then expect(actual.event_id).to eq expected[:event_id] else true end
+    expect(actual.event_type).to eq expected.event_type
+    expect(actual.data).to eq expected.data
+    if expected.event_id then expect(actual.event_id).to eq expected.event_id else true end
   end
 end

--- a/spec/actions/create_events_in_stream_spec.rb
+++ b/spec/actions/create_events_in_stream_spec.rb
@@ -10,8 +10,7 @@ module RubyEventStore
       event = OrderCreated.new(event_id: 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd')
       facade.append_to_stream(stream_name, event)
       saved_events = facade.read_stream_events_forward(stream_name)
-      expected = {event_id: 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd', event_type: 'OrderCreated', data: {}}
-      expect(saved_events[0]).to be_event(expected)
+      expect(saved_events[0]).to eq(event)
     end
 
     specify 'generate guid and create successfully event' do
@@ -19,8 +18,7 @@ module RubyEventStore
       event = OrderCreated.new
       facade.append_to_stream(stream_name, event)
       saved_events = facade.read_stream_events_forward(stream_name)
-      expected = {event_type: 'OrderCreated', data: {}}
-      expect(saved_events[0]).to be_event(expected)
+      expect(saved_events[0]).to eq(event)
     end
 
     specify 'raise exception if event version incorrect' do
@@ -49,8 +47,7 @@ module RubyEventStore
       facade.subscribe_to_all_events(handler)
       facade.append_to_stream(stream_name, event)
       saved_events = facade.read_stream_events_forward(stream_name)
-      expected = {event_type: 'OrderCreated', data: {}}
-      expect(saved_events[0]).to be_event(expected)
+      expect(saved_events[0]).to eq(event)
     end
 
     specify 'expect publish to call event handlers' do
@@ -61,8 +58,7 @@ module RubyEventStore
       facade.subscribe_to_all_events(handler)
       facade.publish_event(event, stream_name)
       saved_events = facade.read_stream_events_forward(stream_name)
-      expected = {event_type: 'OrderCreated', data: {}}
-      expect(saved_events[0]).to be_event(expected)
+      expect(saved_events[0]).to eq(event)
     end
 
     specify 'create global event without stream name' do
@@ -70,8 +66,7 @@ module RubyEventStore
       event = OrderCreated.new
       facade.publish_event(event)
       saved_events = facade.read_stream_events_forward('all')
-      expected = {event_type: 'OrderCreated', stream: 'all', data: {}}
-      expect(saved_events[0]).to be_event(expected)
+      expect(saved_events[0]).to eq(event)
     end
   end
 end

--- a/spec/actions/read_all_events_spec.rb
+++ b/spec/actions/read_all_events_spec.rb
@@ -4,6 +4,10 @@ module RubyEventStore
   describe Facade do
     let(:stream_name) { 'stream_name' }
 
+    before do
+      allow(Time).to receive(:now).and_return(Time.now)
+    end
+
     specify 'raise exception if stream name is incorrect' do
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       expect { facade.read_stream_events_forward(nil) }.to raise_error(IncorrectStreamData)
@@ -16,20 +20,20 @@ module RubyEventStore
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       prepare_events_in_store(facade)
       events = facade.read_stream_events_forward(stream_name)
-      expect(events[0]).to be_event({event_id: '0', event_type: 'OrderCreated', data: {}})
-      expect(events[1]).to be_event({event_id: '1', event_type: 'OrderCreated', data: {}})
-      expect(events[2]).to be_event({event_id: '2', event_type: 'OrderCreated', data: {}})
-      expect(events[3]).to be_event({event_id: '3', event_type: 'OrderCreated', data: {}})
+      expect(events[0]).to eq(OrderCreated.new(event_id: '0'))
+      expect(events[1]).to eq(OrderCreated.new(event_id: '1'))
+      expect(events[2]).to eq(OrderCreated.new(event_id: '2'))
+      expect(events[3]).to eq(OrderCreated.new(event_id: '3'))
     end
 
     specify 'return all events ordered backward' do
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       prepare_events_in_store(facade)
       events = facade.read_stream_events_backward(stream_name)
-      expect(events[0]).to be_event({event_id: '3', event_type: 'OrderCreated', data: {}})
-      expect(events[1]).to be_event({event_id: '2', event_type: 'OrderCreated', data: {}})
-      expect(events[2]).to be_event({event_id: '1', event_type: 'OrderCreated', data: {}})
-      expect(events[3]).to be_event({event_id: '0', event_type: 'OrderCreated', data: {}})
+      expect(events[0]).to eq(OrderCreated.new(event_id: '3'))
+      expect(events[1]).to eq(OrderCreated.new(event_id: '2'))
+      expect(events[2]).to eq(OrderCreated.new(event_id: '1'))
+      expect(events[3]).to eq(OrderCreated.new(event_id: '0'))
     end
 
     private

--- a/spec/actions/read_events_batch_spec.rb
+++ b/spec/actions/read_events_batch_spec.rb
@@ -4,6 +4,10 @@ module RubyEventStore
   describe Facade do
     let(:stream_name) { 'stream_name' }
 
+    before do
+      allow(Time).to receive(:now).and_return(Time.now)
+    end
+
     specify 'raise exception if stream name is incorrect' do
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       expect { facade.read_events_forward(nil, 1, 1) }.to raise_error(IncorrectStreamData)
@@ -36,31 +40,31 @@ module RubyEventStore
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       prepare_events_in_store(facade)
       events = facade.read_events_forward(stream_name, 1, 3)
-      expect(events[0]).to be_event({event_id: '2', event_type: 'OrderCreated', stream: stream_name, data: {}})
-      expect(events[1]).to be_event({event_id: '3', event_type: 'OrderCreated', stream: stream_name, data: {}})
+      expect(events[0]).to eq(OrderCreated.new(event_id: '2'))
+      expect(events[1]).to eq(OrderCreated.new(event_id: '3'))
     end
 
     specify 'return specified number of events ordered forward' do
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       prepare_events_in_store(facade)
       events = facade.read_events_forward(stream_name, 1, 1)
-      expect(events[0]).to be_event({event_id: '2', event_type: 'OrderCreated', stream: stream_name, data: {}})
+      expect(events[0]).to eq(OrderCreated.new(event_id: '2'))
     end
 
     specify 'return all events ordered backward' do
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       prepare_events_in_store(facade)
       events = facade.read_events_backward(stream_name, 2, 3)
-      expect(events[0]).to be_event({event_id: '1', event_type: 'OrderCreated', stream: stream_name, data: {}})
-      expect(events[1]).to be_event({event_id: '0', event_type: 'OrderCreated', stream: stream_name, data: {}})
+      expect(events[0]).to eq(OrderCreated.new(event_id: '1'))
+      expect(events[1]).to eq(OrderCreated.new(event_id: '0'))
     end
 
     specify 'return specified number of events ordered backward' do
       facade = RubyEventStore::Facade.new(InMemoryRepository.new)
       prepare_events_in_store(facade)
       events = facade.read_events_backward(stream_name, 3, 2)
-      expect(events[0]).to be_event({event_id: '2', event_type: 'OrderCreated', stream: stream_name, data: {}})
-      expect(events[1]).to be_event({event_id: '1', event_type: 'OrderCreated', stream: stream_name, data: {}})
+      expect(events[0]).to eq(OrderCreated.new(event_id: '2'))
+      expect(events[1]).to eq(OrderCreated.new(event_id: '1'))
     end
 
     specify 'fails when starting event not exists' do

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -10,7 +10,7 @@ module RubyEventStore
 
     specify 'constructor attributes are used as event data' do
       event = Test::TestCreated.new(sample: 123)
-      expect(event.event_type).to eq          'Test::TestCreated'
+      expect(event.event_type).to eq          Test::TestCreated
       expect(event.event_id).to_not           be_nil
       expect(event.sample).to                 eq(123)
       expect(event.data).to                   eq({sample: 123})
@@ -19,16 +19,8 @@ module RubyEventStore
 
     specify 'constructor event_id attribute is used as event id' do
       event = Test::TestCreated.new(event_id: 234)
-      expect(event.event_type).to eq          'Test::TestCreated'
+      expect(event.event_type).to eq          Test::TestCreated
       expect(event.event_id).to               eq("234")
-      expect(event.data).to                   eq({})
-      expect(event.metadata[:timestamp]).to   be_a Time
-    end
-
-    specify 'constructor event_type attribute is used as event type' do
-      event = Test::TestCreated.new(event_type: 'DifferentTestPublished')
-      expect(event.event_type).to eq          'DifferentTestPublished'
-      expect(event.event_id).to_not           be_nil
       expect(event.data).to                   eq({})
       expect(event.metadata[:timestamp]).to   be_a Time
     end
@@ -36,7 +28,6 @@ module RubyEventStore
     specify 'constructor metadata attribute is used as event metadata (with timestamp changed)' do
       timestamp = Time.utc(2016, 3, 10, 15, 20)
       event = Test::TestCreated.new(metadata: {created_by: 'Someone', timestamp: timestamp})
-      expect(event.event_type).to eq          'Test::TestCreated'
       expect(event.event_id).to_not           be_nil
       expect(event.data).to                   eq({})
       expect(event.timestamp).to              eq(timestamp)
@@ -45,7 +36,7 @@ module RubyEventStore
 
     specify 'for empty data it initializes instance with default values' do
       event = Test::TestCreated.new
-      expect(event.event_type).to eq          'Test::TestCreated'
+      expect(event.event_type).to eq          Test::TestCreated
       expect(event.event_id).to_not           be_nil
       expect(event.data).to                   eq({})
       expect(event.metadata[:timestamp]).to   be_a Time
@@ -70,15 +61,44 @@ module RubyEventStore
       expect(event.event_id).to match(uuid_regexp)
     end
 
+    specify 'two events are equal if their attributes are equal' do
+      event_data = { foo: 'bar' }
+      event_metadata = { timestamp: Time.now }
+      event = Test::TestCreated.new(event_id: '1', data: event_data, metadata: event_metadata)
+      same_event = Test::TestCreated.new(event_id: '1', data: event_data, metadata: event_metadata)
+      expect(event).to eq(same_event)
+    end
+
+    specify 'two events are not equal if their payload is different' do
+      event_data = { foo: 'bar' }
+      event_metadata = { timestamp: Time.now }
+      event = Test::TestCreated.new(event_id: '1', data: event_data, metadata: event_metadata)
+      different_event = Test::TestCreated.new(event_id: '1', data: event_data.merge(price: 123), metadata: event_metadata)
+      expect(event).not_to eq(different_event)
+    end
+
+    specify 'two events are not equal if their types are different' do
+      TestDeleted = Class.new(RubyEventStore::Event)
+      event_metadata = { timestamp: Time.now }
+      event = Test::TestCreated.new(event_id: '1', metadata: event_metadata)
+      different_event = TestDeleted.new(event_id: '1', metadata: event_metadata)
+      expect(event).not_to eq(different_event)
+    end
+
+    specify 'an event and a random object are different' do
+      event = Test::TestCreated.new
+      object = Object.new
+      expect(event).not_to eq(object)
+    end
+
     specify 'convert to hash' do
       event_data = {
-          event_type: 'OrderCreated',
           data: { data: 'sample' },
           event_id: 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd',
           metadata: { meta: 'test'}
       }
       event = Test::TestCreated.new(event_data)
-      expect(event.to_h[:event_type]).to eq 'OrderCreated'
+      expect(event.to_h[:event_type]).to eq 'Test::TestCreated'
       expect(event.to_h[:event_id]).to eq 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd'
       expect(event.to_h[:data]).to eq({ data: 'sample' })
       expect(event.to_h[:metadata][:meta]).to eq('test')
@@ -91,12 +111,11 @@ module RubyEventStore
       allow_any_instance_of(Time).to receive(:now).and_return(now)
       allow_any_instance_of(Time).to receive(:utc).and_return(utc)
       event_data = {
-          event_type: 'OrderCreated',
           data: { data: 'sample' },
           event_id: 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd',
       }
       event = Test::TestCreated.new(event_data)
-      expect(event.to_h[:event_type]).to eq 'OrderCreated'
+      expect(event.to_h[:event_type]).to eq 'Test::TestCreated'
       expect(event.to_h[:event_id]).to eq 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd'
       expect(event.to_h[:metadata][:timestamp]).to eq utc
       expect(event.to_h[:data]).to eq({ data: 'sample' })

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -11,7 +11,7 @@ module Subscribers
     attr_reader :handled_events
 
     def handle_event(event)
-      @handled_events += 1 if event.event_type == 'OrderCreated' || event.event_type == 'ProductAdded'
+      @handled_events += 1 if event.event_type == OrderCreated || event.event_type == ProductAdded
     end
   end
 end
@@ -43,7 +43,7 @@ module RubyEventStore
 
     specify 'notifies subscribers listening on list of events' do
       subscriber = Subscribers::OrderDenormalizer.new
-      facade.subscribe(subscriber, ['OrderCreated', 'ProductAdded'])
+      facade.subscribe(subscriber, [OrderCreated, ProductAdded])
       event_1 = OrderCreated.new
       event_2 = ProductAdded.new
       facade.publish_event(event_1)

--- a/spec/support/matchers/event_store_matcher.rb
+++ b/spec/support/matchers/event_store_matcher.rb
@@ -1,7 +1,0 @@
-RSpec::Matchers.define :be_event do |expected|
-  match do |actual|
-    expect(actual.event_type).to eq expected[:event_type]
-    expect(actual.data).to eq expected[:data]
-    if expected.key? :event_id then expect(actual.event_id).to eq expected[:event_id] else true end
-  end
-end


### PR DESCRIPTION
Before:

```ruby
  es.subscribe(Handler, ['OrderCreated', 'OrderExpired'])
```

After:
```ruby
  es.subscribe(Handler, [OrderCreated, OrderExpired])
```

This commit makes subscriptions consistent. Previously
handlers were supplied as a class and events as a string.
After this change strings are no longer used.

Other than that by using class names you can ensure
that the subscribed event really exists. If it doesn't
then a NameError is raised.

In order to achieve that, the ability to specify an event_type
in constructor has been removed.

    TestEvent.new(event_type: 'OrderCreated') # doesn't work anymore

Of course this change is not backward compatible.
I think it would be possible to introduce a compatibility layer
and for the time being allow to subscribe by both class names and
strings.