### PR TITLE
Don't overwrite timestamps

### DIFF
--- a/lib/ruby_event_store/event.rb
+++ b/lib/ruby_event_store/event.rb
@@ -10,8 +10,9 @@ module RubyEventStore
 
       @event_type = args[:event_type] || event_name
       @event_id   = (args[:event_id]  || generate_id).to_s
-      @metadata   = (args[:metadata]  || {}).merge!(timestamp)
+      @metadata   = args[:metadata]   || {}
       @data       = attributes(args)
+      @metadata[:timestamp] ||= Time.now.utc
     end
     attr_reader :event_type, :event_id, :metadata, :data
 
@@ -24,14 +25,14 @@ module RubyEventStore
       }
     end
 
+    def timestamp
+      metadata[:timestamp]
+    end
+
     private
 
     def attributes(args)
       args.reject { |k| [:event_type, :event_id, :metadata].include? k }
-    end
-
-    def timestamp
-      { timestamp: Time.now.utc }
     end
 
     def generate_id

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -34,11 +34,12 @@ module RubyEventStore
     end
 
     specify 'constructor metadata attribute is used as event metadata (with timestamp changed)' do
-      event = Test::TestCreated.new(metadata: {created_by: 'Someone'})
+      timestamp = Time.utc(2016, 3, 10, 15, 20)
+      event = Test::TestCreated.new(metadata: {created_by: 'Someone', timestamp: timestamp})
       expect(event.event_type).to eq          'Test::TestCreated'
       expect(event.event_id).to_not           be_nil
       expect(event.data).to                   eq({})
-      expect(event.metadata[:timestamp]).to   be_a Time
+      expect(event.timestamp).to              eq(timestamp)
       expect(event.metadata[:created_by]).to  eq('Someone')
     end
 


### PR DESCRIPTION
It fixes a bug with Event constructor overwriting
a timestamp passed in metadata.

After this change a timestamp is assigned only if it's not
already provided.