### PR TITLE
Remove Event#event_type

### DIFF
--- a/lib/ruby_event_store/event.rb
+++ b/lib/ruby_event_store/event.rb
@@ -15,13 +15,8 @@ module RubyEventStore
     end
     attr_reader :event_id, :metadata, :data
 
-    def event_type
-      self.class
-    end
-
     def to_h
       {
-          event_type: event_type.name,
           event_id:   event_id,
           metadata:   metadata,
           data:       data

--- a/lib/ruby_event_store/pub_sub/broker.rb
+++ b/lib/ruby_event_store/pub_sub/broker.rb
@@ -18,7 +18,7 @@ module RubyEventStore
       end
 
       def notify_subscribers(event)
-        all_subscribers_for(event.event_type).each do |subscriber|
+        all_subscribers_for(event.class).each do |subscriber|
           subscriber.handle_event(event)
         end
       end

--- a/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -14,9 +14,9 @@ RSpec.shared_examples :event_repository do |repository_class|
   it 'created event is stored in given stream' do
     expected_event = TestDomainEvent.new(data: {})
     created = repository.create(expected_event, 'stream')
-    expect_to_be_like_event(created, expected_event)
-    expect_to_be_like_event(repository.read_all_streams_forward(:head, 1).first, expected_event)
-    expect_to_be_like_event(repository.read_stream_events_forward('stream').first, expected_event)
+    expect(created).to eq(expected_event)
+    expect(repository.read_all_streams_forward(:head, 1).first).to eq(expected_event)
+    expect(repository.read_stream_events_forward('stream').first).to eq(expected_event)
     expect(repository.read_stream_events_forward('other_stream')).to be_empty
   end
 
@@ -93,13 +93,5 @@ RSpec.shared_examples :event_repository do |repository_class|
     expect(repository.read_all_streams_backward(:head, 100).map(&:event_id)).to eq event_ids.reverse
     expect(repository.read_all_streams_backward('5', 4).map(&:event_id)).to eq ['4','3','2','1']
     expect(repository.read_all_streams_backward('5', 100).map(&:event_id)).to eq ['4','3','2','1']
-  end
-
-  private
-
-  def expect_to_be_like_event(actual, expected)
-    expect(actual.event_type).to eq expected.event_type
-    expect(actual.data).to eq expected.data
-    if expected.event_id then expect(actual.event_id).to eq expected.event_id else true end
   end
 end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -10,7 +10,6 @@ module RubyEventStore
 
     specify 'constructor attributes are used as event data' do
       event = Test::TestCreated.new(sample: 123)
-      expect(event.event_type).to eq          Test::TestCreated
       expect(event.event_id).to_not           be_nil
       expect(event.sample).to                 eq(123)
       expect(event.data).to                   eq({sample: 123})
@@ -19,7 +18,6 @@ module RubyEventStore
 
     specify 'constructor event_id attribute is used as event id' do
       event = Test::TestCreated.new(event_id: 234)
-      expect(event.event_type).to eq          Test::TestCreated
       expect(event.event_id).to               eq("234")
       expect(event.data).to                   eq({})
       expect(event.metadata[:timestamp]).to   be_a Time
@@ -36,7 +34,6 @@ module RubyEventStore
 
     specify 'for empty data it initializes instance with default values' do
       event = Test::TestCreated.new
-      expect(event.event_type).to eq          Test::TestCreated
       expect(event.event_id).to_not           be_nil
       expect(event.data).to                   eq({})
       expect(event.metadata[:timestamp]).to   be_a Time
@@ -98,7 +95,6 @@ module RubyEventStore
           metadata: { meta: 'test'}
       }
       event = Test::TestCreated.new(event_data)
-      expect(event.to_h[:event_type]).to eq 'Test::TestCreated'
       expect(event.to_h[:event_id]).to eq 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd'
       expect(event.to_h[:data]).to eq({ data: 'sample' })
       expect(event.to_h[:metadata][:meta]).to eq('test')
@@ -115,7 +111,6 @@ module RubyEventStore
           event_id: 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd',
       }
       event = Test::TestCreated.new(event_data)
-      expect(event.to_h[:event_type]).to eq 'Test::TestCreated'
       expect(event.to_h[:event_id]).to eq 'b2d506fd-409d-4ec7-b02f-c6d2295c7edd'
       expect(event.to_h[:metadata][:timestamp]).to eq utc
       expect(event.to_h[:data]).to eq({ data: 'sample' })

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -11,7 +11,7 @@ module Subscribers
     attr_reader :handled_events
 
     def handle_event(event)
-      @handled_events += 1 if event.event_type == OrderCreated || event.event_type == ProductAdded
+      @handled_events += 1 if event.is_a?(OrderCreated) || event.is_a?(ProductAdded)
     end
   end
 end


### PR DESCRIPTION
The event_type method is no longer needed.
If you need to get type of an event just use `event.class`