### PR TITLE
Ability to provide a custom dispatcher to PubSub::Broker

### DIFF
--- a/lib/ruby_event_store/pub_sub/broker.rb
+++ b/lib/ruby_event_store/pub_sub/broker.rb
@@ -1,10 +1,12 @@
 module RubyEventStore
   module PubSub
     class Broker
+      DEFAULT_DISPATCHER = ->(subscriber, event) { subscriber.handle_event(event) }
 
-      def initialize
+      def initialize(dispatcher = DEFAULT_DISPATCHER)
         @subscribers = Hash.new {|hsh, key| hsh[key] = [] }
         @global_subscribers = []
+        @dispatcher = dispatcher
       end
 
       def add_subscriber(subscriber, event_types)
@@ -19,12 +21,12 @@ module RubyEventStore
 
       def notify_subscribers(event)
         all_subscribers_for(event.class).each do |subscriber|
-          subscriber.handle_event(event)
+          dispatcher.call(subscriber, event)
         end
       end
 
       private
-      attr_reader :subscribers
+      attr_reader :subscribers, :dispatcher
 
       def verify_subscriber(subscriber)
         raise SubscriberNotExist if subscriber.nil?


### PR DESCRIPTION
It allows to provide a dispatcher that decides whether
an event should be handled in a sync or an async way.

```ruby
class AsyncDispatcher
  def call(subscriber, event)
    if subscriber.is_a?(ActiveJob::Base)
      subscriber.perform_later(event)
    else
      subscriber.handle_event(event)
    end
  end
end

broker = RubyEventStore::PubSub::Broker.new(AsyncDispatcher.new)
es = RubyEventStore::Facade.new(repo, broker)
```

It can also be used to notify remote subscribers:

```ruby
class RemoteDispatcher
  def initialize(http)
    @http = http
  end

  def call(subscriber_url, event)
    @http.post(subscriber_url, data: event.to_hash)
  end
end

broker = RubyEventStore::PubSub::Broker.new(RemoteDispatcher.new(HttpClient.new))
es = RubyEventStore::Facade.new(repo, broker)
es.subscribe("http://api.example.com/webhook", [OrderCreated, OrderExpired])
```

In fact, such customisations are already possible. You can replace
the entire PubSub mechanism and provide custom implementation.

However, by providing a custom dispatcher you can utilize
the existing PubSub mechanism and customise it for your needs.