### PR TITLE
Added prettier message for case of missing #handle_event method.

### DIFF
--- a/lib/ruby_event_store/pub_sub/broker.rb
+++ b/lib/ruby_event_store/pub_sub/broker.rb
@@ -30,7 +30,7 @@ module RubyEventStore
 
       def verify_subscriber(subscriber)
         raise SubscriberNotExist if subscriber.nil?
-        raise MethodNotDefined unless subscriber.methods.include? :handle_event
+        ensure_method_defined(subscriber)
       end
 
       def subscribe(subscriber, event_types)
@@ -39,8 +39,18 @@ module RubyEventStore
         end
       end
 
+      def ensure_method_defined(subscriber)
+        unless subscriber.methods.include? :handle_event
+          raise MethodNotDefined.new(method_not_defined_message(subscriber))
+        end
+      end
+
       def all_subscribers_for(event_type)
         subscribers[event_type] + @global_subscribers
+      end
+
+      def method_not_defined_message(subscriber)
+        "#handle_event method is not found in #{subscriber.class.to_s} subscriber. Are you sure it is a valid subscriber?"
       end
     end
   end

--- a/lib/ruby_event_store/pub_sub/broker.rb
+++ b/lib/ruby_event_store/pub_sub/broker.rb
@@ -50,7 +50,7 @@ module RubyEventStore
       end
 
       def method_not_defined_message(subscriber)
-        "#handle_event method is not found in #{subscriber.class.to_s} subscriber. Are you sure it is a valid subscriber?"
+        "#handle_event method is not found in #{subscriber.class} subscriber. Are you sure it is a valid subscriber?"
       end
     end
   end

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -41,7 +41,12 @@ module RubyEventStore
 
     specify 'throws exception if subscriber has not handle_event method' do
       subscriber = Subscribers::IncorrectDenormalizer.new
-      expect { facade.subscribe(subscriber, [])}.to raise_error(MethodNotDefined)
+      message = "#handle_event method is not found " +
+                "in Subscribers::IncorrectDenormalizer subscriber." +
+                " Are you sure it is a valid subscriber?"
+
+      expect { facade.subscribe(subscriber, [])}.to raise_error(MethodNotDefined,
+                                                                message)
       expect { facade.subscribe_to_all_events(subscriber)}.to raise_error(MethodNotDefined)
     end
 


### PR DESCRIPTION
I believe it is quite common mistake to make. Current error gives no
insight and next action what should be done. Since this library is
created for people, not robots it's quite a good idea to give more
insight inside the customized message. I've added such message so it should be a little bit friendlier for beginners to start.