### PR TITLE
Allows to customized repository instance

### DIFF
--- a/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples :event_repository do |repository_class|
   TestDomainEvent = Class.new(RubyEventStore::Event)
-  subject(:repository)  { repository_class.new }
+  let(:repository) { subject || repository_class.new }
 
   it 'just created is empty' do
     expect(repository.read_all_streams_forward(:head, 1)).to be_empty


### PR DESCRIPTION
We should allow to pass a custom repository instance defined by the client. For example:

```
describe RailsEventStoreMongoid::EventRepository do

  subject(:repository) { described_class.new(adapter: InMemoryAdapter.new) }

  it_behaves_like :event_repository, described_class

end
```