### PR TITLE
Dropped ClosedStruct event (meta)data wrapping

### DIFF
--- a/lib/ruby_event_store/client.rb
+++ b/lib/ruby_event_store/client.rb
@@ -76,11 +76,11 @@ module RubyEventStore
     attr_reader :metadata_proc
 
     def enrich_event_metadata(event)
-      metadata = event.metadata.to_h
+      metadata = event.metadata
       metadata[:timestamp] ||= Time.now.utc
       metadata.merge!(metadata_proc.call || {}) if metadata_proc
 
-      event.class.new(event_id: event.event_id, metadata: metadata, data: event.data.to_h)
+      event.class.new(event_id: event.event_id, metadata: metadata, data: event.data)
     end
 
     def handle_subscribe(unsub)

--- a/lib/ruby_event_store/event.rb
+++ b/lib/ruby_event_store/event.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 module RubyEventStore
   class Event
-    def initialize(event_id: SecureRandom.uuid, metadata: {}, data: {})
+    def initialize(event_id: SecureRandom.uuid, metadata: nil, data: nil)
       @event_id = event_id.to_s
       @metadata = metadata.to_h
       @data     = data.to_h

--- a/lib/ruby_event_store/event.rb
+++ b/lib/ruby_event_store/event.rb
@@ -1,25 +1,24 @@
 require 'securerandom'
-require 'closed_struct'
 
 module RubyEventStore
   class Event
     def initialize(event_id: SecureRandom.uuid, metadata: {}, data: {})
       @event_id = event_id.to_s
-      @metadata = ClosedStruct.new(metadata)
-      @data     = ClosedStruct.new(data)
+      @metadata = metadata.to_h
+      @data     = data.to_h
     end
     attr_reader :event_id, :metadata, :data
 
     def to_h
       {
           event_id:   event_id,
-          metadata:   metadata.to_h,
-          data:       data.to_h
+          metadata:   metadata,
+          data:       data
       }
     end
 
     def timestamp
-      metadata.timestamp rescue nil
+      metadata[:timestamp]
     end
 
     def ==(other_event)

--- a/lib/ruby_event_store/spec/event_repository_lint.rb
+++ b/lib/ruby_event_store/spec/event_repository_lint.rb
@@ -24,14 +24,14 @@ RSpec.shared_examples :event_repository do |repository_class|
     event = TestDomainEvent.new(data: { order_id: 3 })
     repository.create(event, 'stream')
     retrieved_event = repository.read_all_streams_forward(:head, 1).first
-    expect(retrieved_event.data.order_id).to eq(3)
+    expect(retrieved_event.data[:order_id]).to eq(3)
   end
 
   it 'metadata attributes are retrieved' do
     event = TestDomainEvent.new(metadata: { request_id: 3 })
     repository.create(event, 'stream')
     retrieved_event = repository.read_all_streams_forward(:head, 1).first
-    expect(retrieved_event.metadata.request_id).to eq(3)
+    expect(retrieved_event.metadata[:request_id]).to eq(3)
   end
 
   it 'does not have deleted streams' do

--- a/ruby_event_store.gemspec
+++ b/ruby_event_store.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'closed_struct', '~> 0.1'
   spec.add_development_dependency 'bundler', '~> 1.8'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'

--- a/spec/actions/read_all_streams_events_spec.rb
+++ b/spec/actions/read_all_streams_events_spec.rb
@@ -10,8 +10,8 @@ module RubyEventStore
       client.publish_event(OrderCreated.new(data: { order_id: 234 }), stream_name: 'order_2')
       response = client.read_all_streams_forward(:head, page_size)
       expect(response.length).to be 2
-      expect(response[0].data.order_id).to eq 123
-      expect(response[1].data.order_id).to eq 234
+      expect(response[0].data[:order_id]).to eq 123
+      expect(response[1].data[:order_id]).to eq 234
     end
 
     specify 'return batch of events from the beginging ordered forward' do
@@ -21,8 +21,8 @@ module RubyEventStore
       client.publish_event(OrderCreated.new(data: { order_id: 345 }), stream_name: 'order_3')
       response = client.read_all_streams_forward(:head, 2)
       expect(response.length).to be 2
-      expect(response[0].data.order_id).to eq 123
-      expect(response[1].data.order_id).to eq 234
+      expect(response[0].data[:order_id]).to eq 123
+      expect(response[1].data[:order_id]).to eq 234
     end
 
     specify 'return batch of events from given event ordered forward' do
@@ -33,7 +33,7 @@ module RubyEventStore
       client.publish_event(OrderCreated.new(data: { order_id: 345 }), stream_name: 'order_3')
       response = client.read_all_streams_forward(uid, 1)
       expect(response.length).to be 1
-      expect(response[0].data.order_id).to eq 234
+      expect(response[0].data[:order_id]).to eq 234
     end
 
     specify 'return all events ordered backward' do
@@ -42,8 +42,8 @@ module RubyEventStore
       client.publish_event(OrderCreated.new(data: { order_id: 234 }), stream_name: 'order_1')
       response = client.read_all_streams_backward(:head, page_size)
       expect(response.length).to be 2
-      expect(response[0].data.order_id).to eq 234
-      expect(response[1].data.order_id).to eq 123
+      expect(response[0].data[:order_id]).to eq 234
+      expect(response[1].data[:order_id]).to eq 123
     end
 
     specify 'return batch of events from the end ordered backward' do
@@ -53,8 +53,8 @@ module RubyEventStore
       client.publish_event(OrderCreated.new(data: { order_id: 345 }), stream_name: 'order_3')
       response = client.read_all_streams_backward(:head, 2)
       expect(response.length).to be 2
-      expect(response[0].data.order_id).to eq 345
-      expect(response[1].data.order_id).to eq 234
+      expect(response[0].data[:order_id]).to eq 345
+      expect(response[1].data[:order_id]).to eq 234
     end
 
     specify 'return batch of events from given event ordered backward' do
@@ -65,7 +65,7 @@ module RubyEventStore
       client.publish_event(OrderCreated.new(data: { order_id: 345 }), stream_name: 'order_3')
       response = client.read_all_streams_backward(uid, 1)
       expect(response.length).to be 1
-      expect(response[0].data.order_id).to eq 123
+      expect(response[0].data[:order_id]).to eq 123
     end
 
     specify 'fails when starting event not exists' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -102,8 +102,8 @@ module RubyEventStore
       client.publish_event(event)
       published = client.read_all_streams_forward(:head, 10)
       expect(published.size).to eq(1)
-      expect(published.first.metadata.request_id).to eq('127.0.0.1')
-      expect(published.first.metadata.timestamp).to be_a Time
+      expect(published.first.metadata[:request_id]).to eq('127.0.0.1')
+      expect(published.first.metadata[:timestamp]).to be_a Time
     end
 
     specify 'only timestamp set inn metadata when event stored in stream if metadata proc return nil' do
@@ -112,8 +112,8 @@ module RubyEventStore
       client.append_to_stream(GLOBAL_STREAM, event)
       published = client.read_all_streams_forward(:head, 10)
       expect(published.size).to eq(1)
-      expect(published.first.metadata.to_h.keys).to eq([:timestamp])
-      expect(published.first.metadata.timestamp).to be_a Time
+      expect(published.first.metadata.keys).to eq([:timestamp])
+      expect(published.first.metadata[:timestamp]).to be_a Time
     end
 
     specify 'timestamp is utc time' do
@@ -126,7 +126,7 @@ module RubyEventStore
       client.publish_event(event)
       published = client.read_all_streams_forward(:head, 10)
       expect(published.size).to eq(1)
-      expect(published.first.metadata.timestamp).to eq(utc)
+      expect(published.first.metadata[:timestamp]).to eq(utc)
     end
   end
 end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -20,34 +20,34 @@ module RubyEventStore
 
     specify 'constructor attributes are used as event data' do
       event = Test::TestCreated.new(data: {sample: 123})
-      expect(event.event_id).to_not           be_nil
-      expect(event.data.sample).to            eq(123)
-      expect(event.data.to_h).to              eq({sample: 123})
-      expect(event.metadata.to_h).to          eq({})
-      expect(event.timestamp).to              be_nil
+      expect(event.event_id).to_not  be_nil
+      expect(event.data[:sample]).to eq(123)
+      expect(event.data).to          eq({sample: 123})
+      expect(event.metadata).to      eq({})
+      expect(event.timestamp).to     be_nil
     end
 
     specify 'constructor event_id attribute is used as event id' do
       event = Test::TestCreated.new(event_id: 234)
-      expect(event.event_id).to               eq("234")
-      expect(event.data.to_h).to              eq({})
-      expect(event.metadata.to_h).to          eq({})
+      expect(event.event_id).to eq("234")
+      expect(event.data).to     eq({})
+      expect(event.metadata).to eq({})
     end
 
     specify 'constructor metadata attribute is used as event metadata (with timestamp changed)' do
       timestamp = Time.utc(2016, 3, 10, 15, 20)
       event = Test::TestCreated.new(metadata: {created_by: 'Someone', timestamp: timestamp})
-      expect(event.event_id).to_not           be_nil
-      expect(event.data.to_h).to              eq({})
-      expect(event.timestamp).to              eq(timestamp)
-      expect(event.metadata.created_by).to    eq('Someone')
+      expect(event.event_id).to_not          be_nil
+      expect(event.data).to                  eq({})
+      expect(event.timestamp).to             eq(timestamp)
+      expect(event.metadata[:created_by]).to eq('Someone')
     end
 
     specify 'for empty data it initializes instance with default values' do
       event = Test::TestCreated.new
-      expect(event.event_id).to_not           be_nil
-      expect(event.data.to_h).to              eq({})
-      expect(event.metadata.to_h).to          eq({})
+      expect(event.event_id).to_not be_nil
+      expect(event.data).to         eq({})
+      expect(event.metadata).to     eq({})
     end
 
     specify 'UUID should be String' do

--- a/spec/projection_spec.rb
+++ b/spec/projection_spec.rb
@@ -15,8 +15,8 @@ module RubyEventStore
       account_balance = Projection.
         from_stream(stream_name).
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount }).
-        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data.amount }).
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
+        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data[:amount] }).
         run(event_store)
       expect(account_balance).to eq(total: 25)
     end
@@ -28,8 +28,8 @@ module RubyEventStore
       account_balance = Projection.
         from_stream("Customer$1", "Customer$3").
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount }).
-        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data.amount }).
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
+        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data[:amount] }).
         run(event_store)
       expect(account_balance).to eq(total: 5)
     end
@@ -43,8 +43,8 @@ module RubyEventStore
       account_balance = Projection.
         from_stream("Customer$1", "Customer$3").
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount }).
-        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data.amount })
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
+        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data[:amount]})
 
       expect(account_balance.run(event_store)).to eq(total: -15)
       expect(account_balance.run(event_store, start: :head)).to eq(total: -15)
@@ -73,8 +73,8 @@ module RubyEventStore
       account_balance = Projection.
         from_all_streams.
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount }).
-        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data.amount })
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
+        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data[:amount] })
 
       expect(account_balance.run(event_store)).to eq(total: 1)
     end
@@ -88,8 +88,8 @@ module RubyEventStore
       account_balance = Projection.
         from_all_streams.
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount }).
-        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data.amount })
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
+        when(MoneyWithdrawn, ->(state, event) { state[:total] -= event.data[:amount] })
 
       expect(account_balance.run(event_store, start: custom_event.event_id, count: 1)).to eq(total: -5)
       expect(account_balance.run(event_store, start: custom_event.event_id, count: 2)).to eq(total: 5)
@@ -115,8 +115,8 @@ module RubyEventStore
       event_store.publish_event(MoneyWithdrawn.new(data: { amount: 5 }),  stream_name: stream_name)
       stats = Projection.
         from_stream(stream_name).
-        when(MoneyDeposited, ->(state, event) { state[:last_deposit]    = event.data.amount }).
-        when(MoneyWithdrawn, ->(state, event) { state[:last_withdrawal] = event.data.amount }).
+        when(MoneyDeposited, ->(state, event) { state[:last_deposit]    = event.data[:amount] }).
+        when(MoneyWithdrawn, ->(state, event) { state[:last_withdrawal] = event.data[:amount] }).
         run(event_store)
       expect(stats).to eq(last_deposit: 20, last_withdrawal: 5)
     end
@@ -128,7 +128,7 @@ module RubyEventStore
       deposits = Projection.
         from_stream(stream_name).
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount }).
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] }).
         run(event_store)
       expect(deposits).to eq(total: 10)
     end
@@ -138,7 +138,7 @@ module RubyEventStore
       deposits = Projection.
         from_stream(stream_name).
         init( -> { { total: 0 } }).
-        when(MoneyDeposited, ->(state, event) { state[:total] += event.data.amount })
+        when(MoneyDeposited, ->(state, event) { state[:total] += event.data[:amount] })
       event_store.subscribe(deposits, deposits.handled_events)
       event_store.publish_event(MoneyDeposited.new(data: { amount: 10 }), stream_name: stream_name)
       event_store.publish_event(MoneyDeposited.new(data: { amount: 5 }), stream_name: stream_name)


### PR DESCRIPTION
It comes out that the way ClosedStruct works internally can cause issues
for some key names. The best example would be trying to initialize event
with `object_id` as data key.

    RubyEventStore::Event.new(data: { object_id: 42 })
    ArgumentError: Cannot define object_id as it already exists
    from /home/xxx/gems/closed_struct-0.1.0/lib/closed_struct.rb:9:in `block in initialize'

Same error will be raised for any key name which is the same as any of
the `Object` methods.

If users want to have object-like behavior, instead of hash-like for
events, they should implement it on their own.

Submitted issue: https://github.com/arkency/ruby_event_store/issues/33